### PR TITLE
Fix syntax error in Template

### DIFF
--- a/src/Theme/Template.php
+++ b/src/Theme/Template.php
@@ -17,7 +17,7 @@ class Template {
 	public function esc_attr( array $attributes ) : string {
 		$e = [];
 		foreach ( $attributes as $k => $v ) {
-			if ( \ is_array( $v ) || \is_object( $v ) ) {
+			if ( \is_array( $v ) || \is_object( $v ) ) {
 				$v = \json_encode( $v );
 			} elseif ( \is_bool( $v ) ) {
 				$v = $v ? 1 : 0;


### PR DESCRIPTION
@lipemat Please consider using @phpstan.

```neon
#$ composer require --dev cmb2/cmb2 johnbillion/extended-cpts szepeviktor/phpstan-wordpress

includes:
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
parameters:
    level: 0
    bootstrapFiles:
        - cmb2-init.php
        - vendor/cmb2/cmb2/includes/CMB2_Options.php
    paths:
        - src/
    ignoreErrors:
        - '#^Unsafe usage of new static#'
```

It is tricky to start CMB2.

```php
<?php
require __DIR__ . '/vendor/cmb2/cmb2/init.php';
define('CMB2_DIR',  __DIR__ . '/vendor/cmb2/cmb2/');
CMB2_Bootstrap_270::initiate()->include_cmb();
```
