### PR TITLE
Fix route rewrite rule regex for API route

### DIFF
--- a/dev/wp-unit/tests/Api/RouteTest.php
+++ b/dev/wp-unit/tests/Api/RouteTest.php
@@ -31,6 +31,12 @@ class RouteTest extends \WP_UnitTestCase {
 		do_action( 'wp_loaded' );
 		$this->go_to( home_url( '/' . self::TEST_ROUTE ) );
 		$this->assertTrue( Route::in()->is_current_route( self::TEST_ROUTE ) );
+
+		$this->go_to( home_url( '/' . self::TEST_ROUTE . '/extra' ) );
+		$this->assertTrue( Route::in()->is_current_route( self::TEST_ROUTE ) );
+
+		$this->go_to( home_url( '/path-before/' . self::TEST_ROUTE . '/extra' ) );
+		$this->assertFalse( Route::in()->is_current_route( self::TEST_ROUTE ) );
 	}
 
 
@@ -38,13 +44,43 @@ class RouteTest extends \WP_UnitTestCase {
 		$this->register_route();
 
 		$this->go_to( home_url( '/' . self::TEST_ROUTE . '/extra/more/' ) );
+		$this->assertTrue( Route::in()->is_current_route( self::TEST_ROUTE ) );
 		$this->assertEquals( 'extra', Route::in()->get_url_parameter() );
 
 		$this->go_to( home_url( '/' . self::TEST_ROUTE . '/another' ) );
+		$this->assertTrue( Route::in()->is_current_route( self::TEST_ROUTE ) );
 		$this->assertEquals( 'another', Route::in()->get_url_parameter() );
 
 		$this->go_to( home_url( '/' . self::TEST_ROUTE ) );
+		$this->assertTrue( Route::in()->is_current_route( self::TEST_ROUTE ) );
 		$this->assertEquals( '', Route::in()->get_url_parameter() );
+	}
+
+
+	/**
+	 * @link https://github.com/lipemat/wordpress-libs/pull/11
+	 */
+	public function test_conflicting_pages(): void {
+		$page = self::factory()->post->create( [
+			'post_title' => 'A Page with test in the slug',
+			'post_type'  => 'page',
+			'post_name'  => self::TEST_ROUTE . '-page',
+		] );
+		$this->register_route();
+
+		$this->go_to( home_url( '/' . self::TEST_ROUTE . '-page' ) );
+		$this->assertFalse( Route::in()->is_current_route( self::TEST_ROUTE ) );
+		$this->assertNull( Route::in()->get_current_route() );
+
+		$this->assertSame( self::TEST_ROUTE . '-page', get_query_var( 'name' ) );
+		$this->assertSame( $page, get_the_ID() );
+
+		$this->go_to( home_url( '/' . self::TEST_ROUTE ) );
+		$this->assertTrue( Route::in()->is_current_route( self::TEST_ROUTE ) );
+		$this->assertSame( [
+			'title'    => 'Test Route',
+			'template' => 'test-route.php',
+		], Route::in()->get_current_route() );
 	}
 
 

--- a/src/Api/Route.php
+++ b/src/Api/Route.php
@@ -227,7 +227,7 @@ class Route {
 		foreach ( $this->routes as $_route => $_args ) {
 			add_rewrite_rule( $_route . '/([^/]+)/?.?', 'index.php?post_type=' . self::POST_TYPE . '&p=' . $this->get_post_id() . '&' . self::QUERY_VAR . '=' . $_route . '&' . self::PARAM_QUERY_VAR . '=$matches[1]', 'top' );
 
-			add_rewrite_rule( $_route, 'index.php?post_type=' . self::POST_TYPE . '&p=' . $this->get_post_id() . '&' . self::QUERY_VAR . '=' . $_route, 'top' );
+			add_rewrite_rule( '^' . $_route . '/?$', 'index.php?post_type=' . self::POST_TYPE . '&p=' . $this->get_post_id() . '&' . self::QUERY_VAR . '=' . $_route, 'top' );
 		}
 	}
 


### PR DESCRIPTION
When a new route is added using `Lipe\Lib\Api\Route` class, this route overrides posts that contain the words of the route that was created:

Steps to reproduce:

1. Create a new route for example "learn"
```php
Route::add( "learn", [ 'title' => 'Learn More', 'template' => get_stylesheet_directory() . '/pages/learn.php' ] );
```
2. Create a post that contains the word `learn` on the title example: "Learn Post"

3. visit the post page URL: https://website.com/learn-post 

**Expected Result:** The post page should be rendered

**Actual Result:**  The route  `learn` is rendered instead.

To fix this, I updated the `rewrite_rule` to use a regex to be more specific when the route should be rendered.

